### PR TITLE
add "download artifacts builder"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 .idea
 *.iml
+work

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+Maven Deployment Linker Plugin for Jenkins
+==========================================
+
+Licensed under [MIT Licence].
+ 
+About
+-----
+This plugin will add a summary on the build of the artifacts uploaded to your maven repository and add a new builder which allows you to download deployed artifacts to a workspace of an other build.
+
+Wiki and Info
+-------------
+User documentation for the plugin can be found on the [wiki]
+
+[wiki]: https://wiki.jenkins-ci.org/display/JENKINS/Maven+Deployment+Linker
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,52 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.jvnet.hudson.plugins</groupId>
-  <artifactId>maven-deployment-linker</artifactId>
-  <version>1.5-SNAPSHOT</version>
-  <packaging>hpi</packaging>
-  <name>Maven Deployment Linker</name>
-  <url>http://wiki.hudson-ci.org/display/HUDSON/Maven+Deployment+Linker</url>
-  <scm>
-    <connection>scm:git:https://github.com/jenkinsci/maven-deployment-linker-plugin.git</connection>
-    <developerConnection>scm:git:https://github.com/jenkinsci/maven-deployment-linker-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/favorite-plugin</url>
-  </scm>
-  <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>1.400</version>
-    </parent>  <developers>
-    <developer>
-      <id>lshatzer</id>
-      <name>Larry Shatzer, Jr.</name>
-      <email>larrys@gmail.com</email>
-    </developer>
-    <developer>
-      <id>vlatombe</id>
-      <name>Vincent Latombe</name>
-      <email>vincent.latombe@gmail.com</email>
-    </developer>
-    <developer>
-      <id>aheritier</id>
-      <name>Arnaud HŽritier</name>
-      <email>aheritier@apache.org</email>
-    </developer>
-  </developers>
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.jvnet.hudson.plugins</groupId>
+	<artifactId>maven-deployment-linker</artifactId>
+	<version>1.5-SNAPSHOT</version>
+	<packaging>hpi</packaging>
+	<name>Maven Deployment Linker</name>
+	<url>http://wiki.hudson-ci.org/display/HUDSON/Maven+Deployment+Linker</url>
+	<scm>
+		<connection>scm:git:https://github.com/jenkinsci/maven-deployment-linker-plugin.git</connection>
+		<developerConnection>scm:git:https://github.com/jenkinsci/maven-deployment-linker-plugin.git</developerConnection>
+		<url>https://github.com/jenkinsci/favorite-plugin</url>
+	</scm>
+	<parent>
+		<groupId>org.jenkins-ci.plugins</groupId>
+		<artifactId>plugin</artifactId>
+		<version>1.406</version>
+	</parent>
+	<developers>
+		<developer>
+			<id>lshatzer</id>
+			<name>Larry Shatzer, Jr.</name>
+			<email>larrys@gmail.com</email>
+		</developer>
+		<developer>
+			<id>vlatombe</id>
+			<name>Vincent Latombe</name>
+			<email>vincent.latombe@gmail.com</email>
+		</developer>
+		<developer>
+			<id>aheritier</id>
+			<name>Arnaud Hï¿½ritier</name>
+			<email>aheritier@apache.org</email>
+		</developer>
+		<developer>
+  		    <id>imod</id>
+            <name>Dominik Bartholdi</name>
+            <email></email>
+		</developer>
+	</developers>
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
+	<repositories>
+		<repository>
+			<id>repo.jenkins-ci.org</id>
+			<url>http://repo.jenkins-ci.org/public/</url>
+		</repository>
+	</repositories>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>repo.jenkins-ci.org</id>
+			<url>http://repo.jenkins-ci.org/public/</url>
+		</pluginRepository>
+	</pluginRepositories>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>async-http-client</artifactId>
+			<version>1.7.4</version>
+		</dependency>
+	</dependencies>
 </project>  
   
 

--- a/src/main/java/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader.java
+++ b/src/main/java/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader.java
@@ -1,0 +1,311 @@
+package hudson.plugins.mavendeploymentlinker;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.RelativePath;
+import hudson.Util;
+import hudson.console.HyperlinkNote;
+import hudson.model.AutoCompletionCandidates;
+import hudson.model.BuildListener;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Hudson;
+import hudson.model.Job;
+import hudson.model.PermalinkProjectAction.Permalink;
+import hudson.model.Run;
+import hudson.plugins.mavendeploymentlinker.MavenDeploymentLinkerAction.ArtifactVersion;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
+import hudson.util.IOUtils;
+import hudson.util.ListBoxModel;
+import hudson.util.ListBoxModel.Option;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import javax.servlet.ServletException;
+
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.Response;
+
+/**
+ * This builder is able to resolve the linked maven artifacts on other projects and use the information to download the deployed artifacts to the local workspace. This allows to save space on the
+ * master, by not having to archive the artifacts for the copyartifact plugin.
+ * 
+ * @author Dominik Bartholdi (imod)
+ * 
+ */
+public class MavenDeploymentDownloader extends Builder {
+
+    private final String projectName;
+    private final String filePattern;
+    private final String targetDir;
+    private final boolean stripVersion;
+    private final boolean failIfNoArtifact;
+    private final boolean cleanTargetDir;
+    private final String stripVersionPattern;
+    private final String permaLink;
+    private transient Pattern filePatternMatcher;
+
+    /**
+     * 
+     * @param projectName
+     *            the name of the project to copy the artifacts from
+     * @param filePattern
+     *            the pattern to find the files to be copied
+     * @param permaLink
+     *            the link to the specific build to copy the artifacts from
+     * @param targetDir
+     *            where to copy the artifacts to
+     * @param stripVersion
+     *            strip the version of the files
+     * @param stripVersionPattern
+     *            overwrite the strip pattern
+     * @param failIfNoArtifact
+     *            fail if there was no artifact to copy
+     * @param cleanTargetDir
+     *            remove the content of the target directory before copying the new files?
+     */
+    @DataBoundConstructor
+    public MavenDeploymentDownloader(String projectName, String filePattern, String permaLink, String targetDir, boolean stripVersion,
+            String stripVersionPattern, boolean failIfNoArtifact, boolean cleanTargetDir) {
+        // check the permissions only if we can
+        StaplerRequest req = Stapler.getCurrentRequest();
+        if (req != null) {
+            // Prevents both invalid values and access to artifacts of projects which this user cannot see.
+            // If value is parameterized, it will be checked when build runs.
+            if (Hudson.getInstance().getItemByFullName(projectName, Job.class) == null) {
+                projectName = ""; // Ignore/clear bad value to avoid ugly 500 page
+            }
+        }
+        this.projectName = projectName;
+        this.filePattern = filePattern;
+        this.targetDir = targetDir;
+        this.stripVersion = stripVersion;
+        this.permaLink = permaLink;
+        this.failIfNoArtifact = failIfNoArtifact;
+        this.cleanTargetDir = cleanTargetDir;
+        this.stripVersionPattern = Util.fixEmpty(stripVersionPattern);
+    }
+
+    private Pattern getFilePatternMatcher() {
+        if (filePatternMatcher == null) {
+            this.filePatternMatcher = filePattern == null ? Pattern.compile(".*") : Pattern.compile(filePattern);
+        }
+        return filePatternMatcher;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public String getFilePattern() {
+        return filePattern;
+    }
+
+    public String getTargetDir() {
+        return targetDir;
+    }
+
+    public boolean isStripVersion() {
+        return stripVersion;
+    }
+
+    public boolean isCleanTargetDir() {
+        return cleanTargetDir;
+    }
+
+    public String getStripVersionPattern() {
+        return stripVersionPattern;
+    }
+
+    public String getPermaLink() {
+        return permaLink;
+    }
+
+    public boolean isFailIfNoArtifact() {
+        return failIfNoArtifact;
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+
+        final PrintStream console = listener.getLogger();
+        final Job<?, ?> job = Hudson.getInstance().getItemByFullName(projectName, Job.class);
+
+        FilePath targetDirFp = new FilePath(build.getWorkspace(), targetDir);
+        if (cleanTargetDir) {
+            console.println("deleting content of " + targetDirFp.getRemote());
+            targetDirFp.deleteContents();
+        }
+        List<MavenDeploymentLinkerAction> linkerActions = Collections.emptyList();
+        for (Permalink link : job.getPermalinks()) {
+            if (link.getId().equals(permaLink)) {
+                final Run<?, ?> resolvedJob = link.resolve(job);
+                linkerActions = resolvedJob.getActions(MavenDeploymentLinkerAction.class);
+
+                {
+                    // do some hyper linked logging
+                    final String jobUrl = Hudson.getInstance().getRootUrl() + "job/" + projectName;
+                    final String linkBuildNr = HyperlinkNote.encodeTo(jobUrl + "/" + resolvedJob.number, "#" + resolvedJob.number);
+                    final String linkPerma = HyperlinkNote.encodeTo(jobUrl + "/" + link.getId(), link.getDisplayName());
+                    final String linkJob = HyperlinkNote.encodeTo(jobUrl, projectName);
+                    console.println(Messages.resolveArtifact(linkBuildNr, linkPerma, linkJob));
+                }
+            }
+        }
+
+        int matchedFiles = 0;
+        for (MavenDeploymentLinkerAction action : linkerActions) {
+            final List<ArtifactVersion> deployments = action.getDeployments();
+            for (ArtifactVersion av : deployments) {
+                String url = av.getUrl();
+                if (StringUtils.isNotBlank(url) && url.startsWith("http")) {
+                    String fileName = "n/a";
+                    try {
+                        // do some basic validation on the url
+                        URL u = new URL(url);
+                        fileName = getFileName(u.getPath(), isStripVersion());
+                    } catch (Exception e) {
+                        console.println(Messages.failedUrlParsing(url, e.getMessage()));
+                        // fall back to simple substitution
+                        fileName = getFileName(url, isStripVersion());
+                    }
+                    // only download files matching the given file pattern
+                    if (getFilePatternMatcher().matcher(fileName).matches()) {
+                        matchedFiles++;
+                        FilePath fp = new FilePath(targetDirFp, fileName);
+                        console.println(Messages.downloadArtifact(HyperlinkNote.encodeTo(url, url), fp.getRemote()));
+                        AsyncHttpClient client = new AsyncHttpClient();
+                        try {
+                            downloadFile(client, url, fp);
+                        } catch (ExecutionException e) {
+                            console.println(Messages.downloadArtifactFailed(HyperlinkNote.encodeTo(url, url), e.getMessage()));
+                            throw new IOException(Messages.downloadArtifactFailed(url, e.getMessage()), e);
+                        }
+                    }
+                }
+            }
+        }
+        if (matchedFiles == 0) {
+            if (failIfNoArtifact) {
+                console.println(Messages.noArtifactFoundError(filePattern));
+                return false;
+            } else {
+                console.println(Messages.noArtifactFoundWarning(filePattern));
+            }
+        }
+
+        return true;
+    }
+
+    private String getFileName(String url, boolean stripVersion) {
+        int slashIndex = url.lastIndexOf('/');
+        String fname = url.substring(slashIndex + 1);
+        if (stripVersion) {
+            fname = stripVersionPattern == null ? VersionUtil.stripeVersion(fname) : VersionUtil.stripeVersion(fname, stripVersionPattern);
+        }
+        return fname;
+    }
+
+    private void downloadFile(AsyncHttpClient client, String url, FilePath target) throws InterruptedException, ExecutionException, IOException {
+        final Response response = client.prepareGet(url).execute().get();
+        final InputStream is = response.getResponseBodyAsStream();
+        IOUtils.copy(is, target.write());// don't close stream...
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl) super.getDescriptor();
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+        public AutoCompletionCandidates doAutoCompleteProjectName(@QueryParameter String value) {
+            final List<Job> jobs = Hudson.getInstance().getItems(Job.class);
+            AutoCompletionCandidates c = new AutoCompletionCandidates();
+            for (Job<?, ?> job : jobs)
+                if (job.getName().toLowerCase().startsWith(value.toLowerCase()))
+                    c.add(job.getName());
+            return c;
+        }
+
+        public ListBoxModel doFillPermaLinkItems(@AncestorInPath Job<?, ?> defaultJob, @RelativePath("..") @QueryParameter("projectName") String projectName) {
+            // gracefully fall back to some job, if none is given
+            Job<?, ?> j = null;
+            if (projectName != null)
+                j = Hudson.getInstance().getItem(projectName, defaultJob, Job.class);
+            if (j == null)
+                j = defaultJob;
+
+            ListBoxModel r = new ListBoxModel();
+            for (Permalink p : j.getPermalinks()) {
+                r.add(new Option(p.getDisplayName(), p.getId()));
+            }
+            return r;
+        }
+
+        /**
+         * checks the file pattern to find the files we have to download.
+         */
+        public FormValidation doCheckFilePattern(@QueryParameter String value) throws IOException, ServletException {
+            String pattern = Util.fixEmptyAndTrim(value);
+            if (pattern == null) {
+                return FormValidation.error(Messages.FilePatternRequired());
+            }
+            try {
+                Pattern.compile(pattern);
+            } catch (PatternSyntaxException e) {
+                return FormValidation.error(Messages.FilePatternInvalidSyntax());
+            }
+            return FormValidation.ok();
+        }
+
+        /**
+         * checks the pattern used to strip the version of the file name - this is optional, as we have a default.
+         * 
+         * @see VersionUtil#SNAPSHOT_FILE_PATTERN_STR
+         * @see VersionUtil#VERSION_FILE_PATTERN_STR
+         */
+        public FormValidation doCheckStripVersionPattern(@QueryParameter String value) throws IOException, ServletException {
+            String pattern = Util.fixEmptyAndTrim(value);
+            if (pattern != null) {
+                try {
+                    Pattern.compile(pattern);
+                } catch (PatternSyntaxException e) {
+                    return FormValidation.error(Messages.StripVersionPatternInvalidSyntax());
+                }
+            }
+            return FormValidation.ok();
+        }
+
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            return true;
+        }
+
+        /**
+         * This human readable name is used in the configuration screen.
+         */
+        public String getDisplayName() {
+            return Messages.MavenDeploymentDownloader_DisplayName();
+        }
+
+    }
+}

--- a/src/main/java/hudson/plugins/mavendeploymentlinker/MavenDeploymentLinkerAction.java
+++ b/src/main/java/hudson/plugins/mavendeploymentlinker/MavenDeploymentLinkerAction.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 public class MavenDeploymentLinkerAction implements Action {
-    private static class ArtifactVersion {
+    /*package*/ static class ArtifactVersion {
         private static final String SNAPSHOT_PATTERN = ".*-SNAPSHOT.*";
         private static final Pattern p = Pattern.compile(SNAPSHOT_PATTERN);
         
@@ -32,6 +32,9 @@ public class MavenDeploymentLinkerAction implements Action {
         }
         public boolean isSnapshot() {
             return snapshot;
+        }
+        public String getUrl() {
+            return url;
         }
         public String getText() {
             StringBuilder textBuilder = new StringBuilder();
@@ -88,4 +91,10 @@ public class MavenDeploymentLinkerAction implements Action {
         deployments.add(artifactVersion);
     }
 
+    /**
+     * @return list of all linked deployments
+     */
+    /*package*/ List<ArtifactVersion> getDeployments() {
+        return deployments;
+    }
 }

--- a/src/main/java/hudson/plugins/mavendeploymentlinker/MavenDeploymentProjectLinkerAction.java
+++ b/src/main/java/hudson/plugins/mavendeploymentlinker/MavenDeploymentProjectLinkerAction.java
@@ -52,7 +52,7 @@ public class MavenDeploymentProjectLinkerAction implements Action {
         for (Run run : builds) {
             if (isSuccessful(run)) {
                 MavenDeploymentLinkerAction linkerAction = run.getAction(MavenDeploymentLinkerAction.class);
-                if (!linkerAction.isSnapshot()) {
+                if (linkerAction != null && !linkerAction.isSnapshot()) {
                     return linkerAction;
                 }
             }

--- a/src/main/java/hudson/plugins/mavendeploymentlinker/VersionUtil.java
+++ b/src/main/java/hudson/plugins/mavendeploymentlinker/VersionUtil.java
@@ -1,0 +1,73 @@
+package hudson.plugins.mavendeploymentlinker;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * some utilities to handle maven version.
+ * 
+ * @author Dominik Bartholdi (imod)
+ * 
+ */
+public class VersionUtil {
+    private static final String SNAPSHOT_FILE_PATTERN_STR = "^(.*)-([0-9.]{0,10})-([0-9]{8}.[0-9]{6})-(.*)(\\.(?i)(.*))$";
+    private static final String VERSION_FILE_PATTERN_STR = "^(.*)-([0-9]{0,10})(-)*?(.*)(-)?(.*)(\\.(?i)(.*))$";
+    private static final Pattern SNAPSHOT_FILE_PATTERN = Pattern.compile(SNAPSHOT_FILE_PATTERN_STR);
+    private static final Pattern VERSION_FILE_PATTERN = Pattern.compile(VERSION_FILE_PATTERN_STR);
+
+    private VersionUtil() {
+    }
+
+    /**
+     * Uses the given pattern to remove the version of the file name.
+     * 
+     * @param fileName
+     *            the name to remove the version from
+     * @param stripPattern
+     *            a regex pattern used to remove the version. first group is used as the new file name and the last group is used as the file extension.
+     * @return the striped name, if the pattern does not match, the original name is returned
+     */
+    public static String stripeVersion(String fileName, String stripPattern) {
+        Matcher m = Pattern.compile(stripPattern).matcher(fileName);
+        if (m.matches()) {
+            return m.group(1) + "." + m.group(m.groupCount());
+        }
+        return fileName;
+    }
+
+    /**
+     * Uses the default patterns to remove the version of the file name.
+     * 
+     * @param fileName
+     *            the name to remove the version from
+     * 
+     * @return the striped name, if the pattern does not match, the original name is returned
+     */
+    public static String stripeVersion(String name) {
+        if (isSnapshot(name)) {
+            Matcher m = SNAPSHOT_FILE_PATTERN.matcher(name);
+            if (m.matches()) {
+                return m.group(1) + "." + m.group(m.groupCount());
+            }
+        } else {
+            Matcher m = VERSION_FILE_PATTERN.matcher(name);
+            if (m.matches()) {
+                return m.group(1) + "." + m.group(m.groupCount());
+            }
+        }
+        return name;
+    }
+
+    static boolean isSnapshot(String baseVersion) {
+        if (baseVersion != null) {
+            Matcher m = SNAPSHOT_FILE_PATTERN.matcher(baseVersion);
+            if (m.matches()) {
+                // for (int i = 0; i < m.groupCount(); i++) {
+                // System.out.println("group " + i + ": " + m.group(i));
+                // }
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/config.jelly
+++ b/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/config.jelly
@@ -1,0 +1,28 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<f:entry title="${%Project}" field="projectName">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Permalink}" field="permaLink">
+		<f:select />
+	</f:entry>
+	<f:entry title="${%Artifacts to copy}" field="filePattern">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Target directory}" field="targetDir">
+		<f:textbox />
+	</f:entry>
+	<f:advanced>
+		<f:entry title="${%Fail if no artifact}" field="failIfNoArtifact">
+			<f:checkbox checked="${instance.isFailIfNoArtifact()}" />
+		</f:entry>
+		<f:entry title="${%Clean target directory}" field="cleanTargetDir">
+			<f:checkbox checked="${instance.isCleanTargetDir()}" />
+		</f:entry>
+		<f:entry title="${%Strip version}" field="stripVersion">
+			<f:checkbox checked="${instance.isStripVersion()}" />
+		</f:entry>
+		<f:entry title="${%Version strip pattern}" field="stripVersionPattern">
+			<f:textbox />
+		</f:entry>
+	</f:advanced>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-cleanTargetDir.html
+++ b/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-cleanTargetDir.html
@@ -1,0 +1,3 @@
+<div>
+	Should the content of the target directory be deleted first?
+</div>

--- a/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-failIfNoArtifact.html
+++ b/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-failIfNoArtifact.html
@@ -1,0 +1,3 @@
+<div>
+	Should the build fail if there was no artifact found to download?
+</div>

--- a/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-filePattern.html
+++ b/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-filePattern.html
@@ -1,0 +1,3 @@
+<div>
+ All files matching this pattern will be copied to the target location. (default: <code>.*</code>)
+</div>

--- a/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-permaLink.html
+++ b/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-permaLink.html
@@ -1,0 +1,3 @@
+<div>
+ Which build of the project should the artifacts be copied from?
+</div>

--- a/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-projectName.html
+++ b/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-projectName.html
@@ -1,0 +1,3 @@
+<div>
+	The project/job from which the artifacts should be copied from. This project must have the 'Link to maven deployments' option enabled, only artifacts which where recorded by the maven deployment linker plugin can be downloaded.  
+</div>

--- a/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-stripVersion.html
+++ b/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-stripVersion.html
@@ -1,0 +1,4 @@
+<div>
+	Should the version be striped of the filenames? <br />With the 'Strip
+	Version Pattern' in the advanced section, one is able to overwrite how the striping is done.
+</div>

--- a/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-stripVersionPattern.html
+++ b/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-stripVersionPattern.html
@@ -1,0 +1,4 @@
+<div> 
+       (optional) The regular expression used to strip the version of the  files. The first group of the pattern will be used as the name of the target file and the last group will be used as the extension of the file.
+       e.g. (firstGroup).(lastGroup)
+</div>

--- a/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-targetDir.html
+++ b/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help-targetDir.html
@@ -1,0 +1,3 @@
+<div>
+ The directory to copy the files to.
+</div>

--- a/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help.html
+++ b/src/main/resources/hudson/plugins/mavendeploymentlinker/MavenDeploymentDownloader/help.html
@@ -1,0 +1,3 @@
+<div>
+	This builder allows to download artifacts which where uploaded to a maven repository. The source project must have the 'Link to maven deployments' option enabled.  
+</div>

--- a/src/main/resources/hudson/plugins/mavendeploymentlinker/Messages.properties
+++ b/src/main/resources/hudson/plugins/mavendeploymentlinker/Messages.properties
@@ -1,1 +1,13 @@
 MavenDeploymentLinkerRecorder_DisplayName=Link to maven deployments
+
+MavenDeploymentDownloader_DisplayName=Get linked maven deployments
+StripVersionPatternInvalidSyntax=invalid pattern (regex) syntax!
+FilePatternInvalidSyntax=invalid pattern (regex) syntax!
+FilePatternRequired=a file pattern is required!
+noArtifactFoundError=[ERROR] maven linker download - no matching file found for: {0}
+noArtifactFoundWarning=[WARNING] maven linker download - no matching file found for: {0}
+resolveArtifact=resolve linked maven artifacts from build number {0} ({1}) on project {2}
+failedUrlParsing=failed parsing the given url: {0} : {1}
+downloadArtifact=download maven artifact: {0} to {1}
+downloadArtifactFailed=failed downloading file {0} : {1}
+

--- a/src/test/java/hudson/plugins/mavendeploymentlinker/FileNameTest.java
+++ b/src/test/java/hudson/plugins/mavendeploymentlinker/FileNameTest.java
@@ -1,0 +1,34 @@
+package hudson.plugins.mavendeploymentlinker;
+
+import junit.framework.TestCase;
+
+/**
+ * @author Dominik Bartholdi (imod)
+ */
+public class FileNameTest extends TestCase {
+
+    private static String NAME1 = "test_AAA_module1-0.0.6-20120501.152207-3.pom";
+    private static String NAME2 = "test-BBB-module1-0.0.6-20120501.152207-3.pom";
+    private static String NAME3 = "test-CCC-module1-10.0.6-20120501.152207-3.pom";
+    private static String NAME4 = "test-CCC-module1-10.0.6.jar";
+    private static String NAME5 = "test_CCC-module1-10-10.0.6.ear";
+    private static String NAME6 = "test-1-module1-10.0.6.pom";
+    private static String NAME7 = "test_1_module1-10.0.6.pom";
+    private static String NAME8 = "test-10-module1-10.0.6-20120501.152207-3.pom";
+    private static String NAME9 = "test-10-module1-9-10.0.6-20120501.152207-3.pom";
+    private static String NAME10 = "test_multi_module1-0.0.6-20120501.152207-3.pom";
+
+    public void testGetBaseName() throws Exception {
+        assertEquals("test_AAA_module1.pom", VersionUtil.stripeVersion(NAME1));
+        assertEquals("test-BBB-module1.pom", VersionUtil.stripeVersion(NAME2));
+        assertEquals("test-CCC-module1.pom", VersionUtil.stripeVersion(NAME3));
+        assertEquals("test-CCC-module1.jar", VersionUtil.stripeVersion(NAME4));
+        assertEquals("test_CCC-module1-10.ear", VersionUtil.stripeVersion(NAME5));
+        assertEquals("test-1-module1.pom", VersionUtil.stripeVersion(NAME6));
+        assertEquals("test_1_module1.pom", VersionUtil.stripeVersion(NAME7));
+        assertEquals("test-10-module1.pom", VersionUtil.stripeVersion(NAME8));
+        assertEquals("test-10-module1-9.pom", VersionUtil.stripeVersion(NAME9));
+        assertEquals("test_multi_module1.pom", VersionUtil.stripeVersion(NAME10));
+    }
+
+}


### PR DESCRIPTION
This pull request adds a new builder which is able to resolve the linked maven artifacts on other projects and use the information to download the deployed artifacts to the local workspace. 
e.g. This allows to save space on the master, by not having to archive the artifacts in a remote maven repo and Jenkins master.
