### PR TITLE
Sending a pull request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.406</version>
+		<version>1.420</version>
 	</parent>
 	<developers>
 		<developer>

--- a/src/main/java/hudson/plugins/mavendeploymentlinker/MavenDeploymentLinkerAction.java
+++ b/src/main/java/hudson/plugins/mavendeploymentlinker/MavenDeploymentLinkerAction.java
@@ -10,13 +10,14 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 public class MavenDeploymentLinkerAction implements Action {
+  
     /*package*/ static class ArtifactVersion {
         private static final String SNAPSHOT_PATTERN = ".*-SNAPSHOT.*";
         private static final Pattern p = Pattern.compile(SNAPSHOT_PATTERN);
         
         private ArtifactVersion(String url) {
             this.url = normalize(url);
-            checkRelease();
+            snapshot = p.matcher(url).matches();
         }
         
         private final String url;
@@ -26,10 +27,7 @@ public class MavenDeploymentLinkerAction implements Action {
         // JENKINS-9114 : Remove "dav:" when Maven uses webdav deployment
             return StringUtils.removeStart(url, "dav:");
         }
-
-        private void checkRelease() {
-            snapshot = p.matcher(url).matches();
-        }
+        
         public boolean isSnapshot() {
             return snapshot;
         }
@@ -50,11 +48,12 @@ public class MavenDeploymentLinkerAction implements Action {
     private List<ArtifactVersion> deployments = new ArrayList<ArtifactVersion>();
     
     private transient String text;
-
-    private boolean snapshot = false;
     
-    public boolean isSnapshot() {
-        return snapshot;
+    public boolean isRelease() {
+        for (ArtifactVersion artifactVersion : deployments) {
+          if (!artifactVersion.isSnapshot()) return true;
+        }
+        return false;
     }
 
     public String getIconFileName() {
@@ -85,9 +84,6 @@ public class MavenDeploymentLinkerAction implements Action {
 
     public void addDeployment(String url) {
         ArtifactVersion artifactVersion = new ArtifactVersion(url);
-        if (artifactVersion.isSnapshot()) {
-            snapshot = true;
-        }
         deployments.add(artifactVersion);
     }
 

--- a/src/main/java/hudson/plugins/mavendeploymentlinker/MavenDeploymentProjectLinkerAction.java
+++ b/src/main/java/hudson/plugins/mavendeploymentlinker/MavenDeploymentProjectLinkerAction.java
@@ -52,7 +52,7 @@ public class MavenDeploymentProjectLinkerAction implements Action {
         for (Run run : builds) {
             if (isSuccessful(run)) {
                 MavenDeploymentLinkerAction linkerAction = run.getAction(MavenDeploymentLinkerAction.class);
-                if (linkerAction != null && !linkerAction.isSnapshot()) {
+                if (linkerAction != null && linkerAction.isRelease()) {
                     return linkerAction;
                 }
             }


### PR DESCRIPTION
We have configured our release jobs to deploy the next SNAPSHOT version after a successful build. This is necessary to allow an automatic version update on depending builds, if they are triggered immediately after the release build (no chance to deploy a SNAPSHOT due to the SCM change). With the current version of the deployment-linker-plugin, such a build would never show release artifacts on the job page.

Therefore it's necessary to allow SNAPSHOT deployments in release builds instead of marking the whole build as a SNAPSHOT. This code change is backwards compatible as it is now dynamically checking the build artifacts. Jenkins may show old plugin data due to the removed field, but this could just be deleted as it's no longer used.
